### PR TITLE
📰 Yellowstone Bears Eat 40,000 Moths a Day In August

### DIFF
--- a/_data/news/2017-07-23-yellowstone-bears-eat-40-000-moths-a-day-in-august.yml
+++ b/_data/news/2017-07-23-yellowstone-bears-eat-40-000-moths-a-day-in-august.yml
@@ -1,0 +1,4 @@
+title: Yellowstone Bears Eat 40,000 Moths a Day In August
+url: https://www.yellowstonepark.com/things-to-do/bears-eat-moths-in-august
+submittedAt: 2017-07-23T01:20:02.084Z
+submittedBy: gr2m-test


### PR DESCRIPTION
Title: Yellowstone Bears Eat 40,000 Moths a Day In August
Url: https://www.yellowstonepark.com/things-to-do/bears-eat-moths-in-august

Submitted with [🥄 Scoop](https://github.com/gr2m/scoop)!