### PR TITLE
📰 A history of why the US is the only rich country without universal health care

### DIFF
--- a/_data/news/2017-07-23-a-history-of-why-the-us-is-the-only-rich-country-without-universal-health-care.yml
+++ b/_data/news/2017-07-23-a-history-of-why-the-us-is-the-only-rich-country-without-universal-health-care.yml
@@ -1,0 +1,4 @@
+title: A history of why the US is the only rich country without universal health care
+url: https://qz.com/1022831/why-doesnt-the-united-states-have-universal-health-care/
+submittedAt: 2017-07-23T04:08:45.650Z
+submittedBy: gr2m


### PR DESCRIPTION
Title: A history of why the US is the only rich country without universal health care
Url: https://qz.com/1022831/why-doesnt-the-united-states-have-universal-health-care/

Submitted with [🥄 Scoop](https://github.com/gr2m/scoop)!