### PR TITLE
📰 Deno subhosting

### DIFF
--- a/_data/news/2023-11-17-deno-subhosting.yml
+++ b/_data/news/2023-11-17-deno-subhosting.yml
@@ -1,0 +1,4 @@
+title: Deno subhosting
+url: https://deno.com/subhosting
+submittedAt: 2023-11-17T17:38:30.636Z
+submittedBy: gr2m


### PR DESCRIPTION
Title: Deno subhosting
Url: https://deno.com/subhosting

Submitted with [🐙📰 Octonews](https://github.com/octonews/octonews)!